### PR TITLE
Fixed additional arguments parsing

### DIFF
--- a/src/runners/MochaTestRunner.ts
+++ b/src/runners/MochaTestRunner.ts
@@ -51,14 +51,19 @@ export class MochaTestRunner implements ITestRunnerInterface {
     const environmentVariables = this.configurationProvider
       .environmentVariables;
 
-    debug.startDebugging(rootPath, {
-      args: [
+    let args = [
         fileName,
         "--grep",
         testName,
-        "--no-timeout",
-        ...additionalArguments.split(" ")
-      ],
+        "--no-timeout"
+    ];
+      
+    if ( additionalArguments ) {
+        args.push(...additionalArguments.split(" "));   
+    }
+      
+    debug.startDebugging(rootPath, {
+      args: args,
       console: "integratedTerminal",
       env: environmentVariables,
       name: "Debug Test",


### PR DESCRIPTION
In case there are no additionalArguments, then debug run fails, because mocha received a "" at the end, yeilds as an invalid path error. (Of course the console only says "killed", right after the debugger has connected.