### PR TITLE
feat: add object spread and optional chaining syntax support

### DIFF
--- a/src/parser/codeParser.ts
+++ b/src/parser/codeParser.ts
@@ -4,7 +4,7 @@ const testTokens = ["describe", "it", "test"];
 
 function codeParser(sourceCode) {
   const ast = parse(sourceCode, {
-    plugins: ["jsx", "typescript"],
+    plugins: ["jsx", "typescript", "objectRestSpread", "optionalChaining"],
     sourceType: "module",
     tokens: true
   });


### PR DESCRIPTION
simplified #4 

enable object spread and optional chaining syntax support. 

VSCode 1.54.3 windows x64 tested